### PR TITLE
feat(isolation): isolate sessions by repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,20 @@ gitea-review done
 4. The agent reads comments via the Gitea API and pushes fixes
 5. `done` removes the container, git remote, and all temp state
 
+### Concurrent Sessions
+
+Each repository gets its own isolated Gitea instance:
+- Container name: `gitea-review-${REPO}` (allows concurrent containers)
+- Port: auto-assigned from repo name hash (3000-3999 range), override with `GITEA_PORT`
+- State file: per-repo in `$TMPDIR`
+
+This prevents multiple sessions from interfering with each other when reviewing different repositories simultaneously.
+
 ## Configuration
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GITEA_PORT` | `3000` | Port for the Gitea web UI |
+| `GITEA_PORT` | Auto-assigned (3000-3999) | Port for the Gitea web UI |
 
 ## Commands
 

--- a/skills/local-code-review/SKILL.md
+++ b/skills/local-code-review/SKILL.md
@@ -32,7 +32,9 @@ Ephemeral GitHub-like PR review via a throwaway local Gitea instance. User revie
 
 ## How It Works
 
-Gitea runs as an ephemeral Docker container with a Caddy reverse proxy that auto-logs the user in (no password needed). The script adds a `gitea` remote alongside `origin`, pushes branches there, and creates PRs. The user reviews at `http://localhost:3000` (override with `GITEA_PORT`). When done, `gitea-review done` removes the container, the remote, and all temp state.
+Gitea runs as an ephemeral Docker container with a Caddy reverse proxy that auto-logs the user in (no password needed). The script adds a `gitea` remote alongside `origin`, pushes branches there, and creates PRs. The user reviews at the auto-assigned port (override with `GITEA_PORT`). When done, `gitea-review done` removes the container, the remote, and all temp state.
+
+Each repository gets its own isolated instance (container, port, state file), so multiple sessions can run concurrently without interfering with each other.
 
 ## Workflow
 
@@ -66,4 +68,4 @@ When the user says "address review comments" or "check PR comments":
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GITEA_PORT` | `3000` | Port for the Gitea web UI |
+| `GITEA_PORT` | Auto-assigned (3000-3999) | Port for the Gitea web UI |

--- a/skills/local-code-review/bin/gitea-review
+++ b/skills/local-code-review/bin/gitea-review
@@ -5,26 +5,35 @@ set -euo pipefail
 # Spins up a throwaway Gitea instance for PR review, tears it down when done.
 # All state lives in TMPDIR and a Docker container -- nothing persists.
 
-CONTAINER="gitea-review"
-PORT="${GITEA_PORT:-3000}"
-URL="http://localhost:${PORT}"
+die() { echo "ERROR: $*" >&2; exit 1; }
+
 USER="review"
 PASS="review"
-STATE_FILE="${TMPDIR:-/tmp}/gitea-review.env"
+
+# Derive repo-specific names to allow concurrent sessions
+git rev-parse --show-toplevel &>/dev/null || die "Not inside a git repository."
+REPO=$(basename "$(git rev-parse --show-toplevel)")
+CONTAINER="gitea-review-${REPO}"
+STATE_FILE="${TMPDIR:-/tmp}/gitea-review-${REPO}.env"
+
+# Auto-assign port based on repo name (hash to 3000-3999 range)
+if [[ -z "${GITEA_PORT:-}" ]]; then
+    REPO_HASH=$(echo -n "$REPO" | cksum | cut -d' ' -f1)
+    PORT=$((3000 + (REPO_HASH % 1000)))
+else
+    PORT="${GITEA_PORT}"
+fi
+URL="http://localhost:${PORT}"
 
 # Load ephemeral state if container is running (safe key=value parsing, no eval)
 TOKEN=""
-REPO=""
 if [[ -f "$STATE_FILE" ]]; then
     while IFS='=' read -r key val; do
         case "$key" in
             TOKEN) TOKEN="$val" ;;
-            REPO) REPO="$val" ;;
         esac
     done < "$STATE_FILE"
 fi
-
-die() { echo "ERROR: $*" >&2; exit 1; }
 
 # Safe JSON construction via python3
 json_obj() { python3 -c "import json,sys; print(json.dumps(dict(zip(sys.argv[1::2],sys.argv[2::2]))))" "$@"; }
@@ -99,10 +108,6 @@ exec /usr/bin/entrypoint' >/dev/null
     TOKEN=$(echo "$token_json" | python3 -c "import sys,json; print(json.load(sys.stdin)['sha1'])")
     [[ -n "$TOKEN" ]] || die "Token extraction failed."
 
-    # Derive repo name from git root
-    git rev-parse --show-toplevel &>/dev/null || die "Not inside a git repository."
-    REPO=$(basename "$(git rev-parse --show-toplevel)")
-
     # Create repo (safe JSON)
     local repo_json
     repo_json=$(python3 -c "import json,sys; print(json.dumps({'name':sys.argv[1],'auto_init':False,'default_branch':'main'}))" "$REPO")
@@ -122,7 +127,6 @@ exec /usr/bin/entrypoint' >/dev/null
     # Save ephemeral state (restricted permissions)
     (umask 077; cat > "$STATE_FILE" <<EOF
 TOKEN=${TOKEN}
-REPO=${REPO}
 EOF
 )
 }
@@ -309,7 +313,7 @@ Lifecycle:
   done                           Tear down Gitea, clean up
 
 Environment:
-  GITEA_PORT                     Override default port (3000)
+  GITEA_PORT                     Override auto-assigned port (3000-3999)
 HELP
 }
 


### PR DESCRIPTION
Each repository gets its own isolated Gitea instance to prevent conflicts:
- Container name: `gitea-review-${REPO}` (allows concurrent containers)
- Port: auto-assigned based on repo name hash (3000-3999 range)
- State file: `${TMPDIR}/gitea-review-${REPO}.env` (per-repo state)

This prevents multiple Claude Code sessions from overwriting each other's review tabs when working on different repositories simultaneously.

Fixes issue where starting review in one repo would tear down another repo's Gitea instance, losing the user's review UI.